### PR TITLE
ChatSpaceのDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|username|string|null: false|
+|name|string|null: false|
 |email|string|null: false|
 |password|string|null: false|
 |password confirmation|string|null: false|

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
 ### Association
 - has_many :messages
 - has_many  :users, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 ### Association
   has_many :images
 - has_many :messages
+  has_many :groups_users
 - has_many  :users, through: :groups_users
 
 ## groups_usersテーブル

--- a/README.md
+++ b/README.md
@@ -22,16 +22,6 @@
 - belongs_to :user
 - belongs_to :group
 
-## imageテーブル
-|Column|Type|Options|
-|------|----|-------|
-|image|text|null: false|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
-### Association
-- belongs_to :user
-- belongs_to :group
-
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@
 |Column|Type|Options|
 |------|----|-------|
 |body|text|null: false|
-|image|text|null: false|
+|image_id|text|null: false, foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
-- belongs_to :user
+- belongs_to :group
 
 ## groupsテーブル
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -1,24 +1,40 @@
-# README
+# ChatSpace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|username|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
+|password confirmation|string|null: false|
+### Association
+- has_many :messages
+- has_many :groups, through: :groups_users
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :user
 
-Things you may want to cover:
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- has_many :messages
+- has_many  :users, through: :groups_users
 
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|groups_id|integer|null: false, foreign_key: true|
+|users_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@
 |Column|Type|Options|
 |------|----|-------|
 |body|text|null: false|
-|image_id|text|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## imageテーブル
+|Column|Type|Options|
+|------|----|-------|
+|image|text|null: false|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 ### Association

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 |password|string|null: false|
 |password confirmation|string|null: false|
 ### Association
-  has_many :images
 - has_many :messages
   has_many :groups_users
 - has_many :groups, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 |password|string|null: false|
 |password confirmation|string|null: false|
 ### Association
+  has_many :images
 - has_many :messages
 - has_many :groups, through: :groups_users
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@
 |------|----|-------|
 |name|string|null: false, foreign_key: true|
 ### Association
-  has_many :images
 - has_many :messages
   has_many :groups_users
 - has_many  :users, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text|
+|image|text|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 ### Association

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|null: false, foreign_key: true|
+|name|string|null: false, foreign_key: true|
 |user_id|integer|null: false, foreign_key: true|
 ### Association
 - has_many :messages

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 |------|----|-------|
 |name|string|null: false, foreign_key: true|
 ### Association
+  has_many :images
 - has_many :messages
 - has_many  :users, through: :groups_users
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ### Association
   has_many :images
 - has_many :messages
+  has_many :groups_users
 - has_many :groups, through: :groups_users
 
 ## messagesテーブル


### PR DESCRIPTION
# What
READMEにChatSpaceのDB設計を記載。
ユーザー、メッセージ、チャットグループのデータを保存するテーブルをそれぞれ設計。
複数人のチャット機能を作成するために、中間テーブルgroups_usersの設計。

# Why
ChatSpace開発のためには必要機能の洗い出しとDBの設計が不可欠であるため。
